### PR TITLE
Fix token parsing in iOS13

### DIFF
--- a/src/Plugin.AzurePushNotification.iOS/AzurePushNotificationManager.cs
+++ b/src/Plugin.AzurePushNotification.iOS/AzurePushNotificationManager.cs
@@ -2,7 +2,6 @@ using Foundation;
 using Plugin.AzurePushNotification.Abstractions;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -17,7 +16,7 @@ namespace Plugin.AzurePushNotification
     /// </summary>
     public class AzurePushNotificationManager : NSObject, IAzurePushNotification, IUNUserNotificationCenterDelegate
     {
-      
+
         static NSString TagsKey = new NSString("Tags");
         static NSString TokenKey = new NSString("Token");
         static NSString EnabledKey = new NSString("Enabled");
@@ -30,14 +29,14 @@ namespace Plugin.AzurePushNotification
             {
                 //Load all subscribed topics
                 IList<string> topics = new List<string>();
-                if(_tags!=null)
+                if (_tags != null)
                 {
                     for (nuint i = 0; i < _tags.Count; i++)
                     {
                         topics.Add(_tags.GetItem<NSString>(i));
                     }
                 }
-               
+
                 return topics.ToArray();
             }
 
@@ -82,8 +81,8 @@ namespace Plugin.AzurePushNotification
 
 
         static SBNotificationHub Hub { get; set; }
-  
-    
+
+
         public static NSData InternalToken
         {
             get
@@ -96,7 +95,7 @@ namespace Plugin.AzurePushNotification
                 NSUserDefaults.StandardUserDefaults.Synchronize();
             }
         }
-        
+
         public IPushNotificationHandler NotificationHandler { get; set; }
 
         public static UNNotificationPresentationOptions CurrentNotificationPresentationOption { get; set; } = UNNotificationPresentationOptions.None;
@@ -174,29 +173,29 @@ namespace Plugin.AzurePushNotification
                 _onNotificationDeleted -= value;
             }
         }
-        public static async Task Initialize(string notificationHubConnectionString, string notificationHubPath, NSDictionary options,bool autoRegistration =true)
+        public static async Task Initialize(string notificationHubConnectionString, string notificationHubPath, NSDictionary options, bool autoRegistration = true)
         {
             Hub = new SBNotificationHub(notificationHubConnectionString, notificationHubPath);
 
             CrossAzurePushNotification.Current.NotificationHandler = CrossAzurePushNotification.Current.NotificationHandler ?? new DefaultPushNotificationHandler();
 
-            if(autoRegistration)
+            if (autoRegistration)
             {
                 await CrossAzurePushNotification.Current.RegisterForPushNotifications();
             }
-          
+
 
         }
 
         public static async Task Initialize(string notificationHubConnectionString, string notificationHubPath, NSDictionary options, IPushNotificationHandler pushNotificationHandler, bool autoRegistration = true)
         {
             CrossAzurePushNotification.Current.NotificationHandler = pushNotificationHandler;
-            await Initialize(notificationHubConnectionString, notificationHubPath,options,autoRegistration);
+            await Initialize(notificationHubConnectionString, notificationHubPath, options, autoRegistration);
         }
-        public static async Task Initialize(string notificationHubConnectionString, string notificationHubPath,NSDictionary options, NotificationUserCategory[] notificationUserCategories, bool autoRegistration = true)
+        public static async Task Initialize(string notificationHubConnectionString, string notificationHubPath, NSDictionary options, NotificationUserCategory[] notificationUserCategories, bool autoRegistration = true)
         {
 
-            await Initialize(notificationHubConnectionString, notificationHubPath, options,autoRegistration);
+            await Initialize(notificationHubConnectionString, notificationHubPath, options, autoRegistration);
             RegisterUserNotificationCategories(notificationUserCategories);
 
         }
@@ -312,7 +311,7 @@ namespace Plugin.AzurePushNotification
 
         }
 
-        
+
         public async Task RegisterAsync(string[] tags)
         {
             System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Register - Start");
@@ -332,7 +331,7 @@ namespace Plugin.AzurePushNotification
             await Task.Run(() =>
             {
                 System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Register - Token {InternalToken}");
-                if (InternalToken!=null && InternalToken.Length > 0)
+                if (InternalToken != null && InternalToken.Length > 0)
                 {
                     NSError errorFirst;
 
@@ -340,17 +339,17 @@ namespace Plugin.AzurePushNotification
 
                     if (errorFirst != null)
                     {
-                        _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubUnregistrationFailed,errorFirst.Description));
+                        _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubUnregistrationFailed, errorFirst.Description));
                         System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Unregister- Error - {errorFirst.Description}");
 
                         return;
                     }
                     NSSet tagSet = null;
-                    if (tags !=null && tags.Length>0)
+                    if (tags != null && tags.Length > 0)
                     {
                         tagSet = new NSSet(tags);
                     }
-             
+
                     NSError error;
 
                     Hub.RegisterNative(InternalToken, tagSet, out error);
@@ -358,7 +357,7 @@ namespace Plugin.AzurePushNotification
                     if (error != null)
                     {
                         System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Register- Error - {error.Description}");
-                        _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubRegistrationFailed,error.Description));
+                        _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubRegistrationFailed, error.Description));
 
                     }
                     else
@@ -366,7 +365,7 @@ namespace Plugin.AzurePushNotification
                         System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Registered - ${tags}");
 
                         NSUserDefaults.StandardUserDefaults.SetBool(true, RegisteredKey);
-                        NSUserDefaults.StandardUserDefaults.SetValueForKey(_tags?? new NSArray().MutableCopy(), TagsKey);
+                        NSUserDefaults.StandardUserDefaults.SetValueForKey(_tags ?? new NSArray().MutableCopy(), TagsKey);
                         NSUserDefaults.StandardUserDefaults.Synchronize();
                     }
                 }
@@ -390,7 +389,7 @@ namespace Plugin.AzurePushNotification
 
                     if (error != null)
                     {
-                        _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubUnregistrationFailed,error.Description));
+                        _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubUnregistrationFailed, error.Description));
                         System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Unregister- Error - {error.Description}");
                     }
                     else
@@ -403,7 +402,7 @@ namespace Plugin.AzurePushNotification
                 }
                 catch (Exception ex)
                 {
-                    _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubUnregistrationFailed,ex.Message));
+                    _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubUnregistrationFailed, ex.Message));
                     System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Unregister- Error - {ex.Message}");
                 }
 
@@ -472,7 +471,7 @@ namespace Plugin.AzurePushNotification
             NSUserDefaults.StandardUserDefaults.SetBool(false, EnabledKey);
             NSUserDefaults.StandardUserDefaults.Synchronize();
 
-            _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.RegistrationFailed,error.Description));
+            _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.RegistrationFailed, error.Description));
         }
 
         static IDictionary<string, object> GetParameters(NSDictionary data)

--- a/src/Plugin.AzurePushNotification.iOS/AzurePushNotificationManager.cs
+++ b/src/Plugin.AzurePushNotification.iOS/AzurePushNotificationManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using UIKit;
 using UserNotifications;
@@ -52,6 +53,23 @@ namespace Plugin.AzurePushNotification
                     trimmedDeviceToken = trimmedDeviceToken.Trim('>');
                     trimmedDeviceToken = trimmedDeviceToken.Trim();
                     trimmedDeviceToken = trimmedDeviceToken.Replace(" ", "");
+                }
+
+                bool aboveiOS13 = UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
+
+                if (aboveiOS13)
+                {
+                    if (InternalToken != null)
+                    {
+                        var token = InternalToken.ToArray();
+                        var hexToken = new StringBuilder(token.Length * 2);
+                        foreach (var b in token)
+                        {
+                            hexToken.AppendFormat("{0:x2}", b);
+                        }
+
+                        trimmedDeviceToken = hexToken.ToString();
+                    }
                 }
 
                 return trimmedDeviceToken ?? string.Empty;


### PR DESCRIPTION
Hi, this PR fix token parsing for iOS 13. The NSData description changed in new iOS13 and the actual underlying token isn't completely written anymore inside it. To get the entire token, we should now extract the token and format each byte from it into a new string. The first method is kept to allow the plugin to work on iOS >=13 as well as iOS <13 .