### PR TITLE
remove fixed version for Xamarin.Firebase.Messaging

### DIFF
--- a/nuget/Plugin.nuspec
+++ b/nuget/Plugin.nuspec
@@ -20,7 +20,7 @@
            <dependency id="NETStandard.Library" version="1.6.1" />
          </group>
         <group targetFramework="MonoAndroid80">
-            <dependency id="Xamarin.Firebase.Messaging" version="[60.1142.1]" />
+            <dependency id="Xamarin.Firebase.Messaging" version="60.1142.1" />
             <dependency id="Xamarin.Azure.NotificationHubs.Android" version="0.4.0" />
             <dependency id="Xamarin.Android.Support.v4" version="26.0.2" />
         </group>

--- a/nuget/Plugin.nuspec
+++ b/nuget/Plugin.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata minClientVersion="2.8.1">
     <id>Plugin.AzurePushNotification</id>
-    <version>1.1.0</version>
+    <version>1.1.3</version>
     <title>Azure Push Notification Plugin for Xamarin</title>
     <authors>Rendy Del Rosario</authors>
     <owners>crossgeeks,rdelrosario</owners>

--- a/src/Plugin.AzurePushNotification.iOS/Plugin.AzurePushNotification.iOS.csproj
+++ b/src/Plugin.AzurePushNotification.iOS/Plugin.AzurePushNotification.iOS.csproj
@@ -49,10 +49,10 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="Xamarin.Azure.NotificationHubs.iOS, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Azure.NotificationHubs.iOS.1.2.5.2\lib\Xamarin.iOS10\Xamarin.Azure.NotificationHubs.iOS.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.iOS" />
+    <Reference Include="Xamarin.Azure.NotificationHubs.iOS">
+      <HintPath>..\..\packages\Xamarin.Azure.NotificationHubs.iOS.2.0.4\lib\xamarinios10\Xamarin.Azure.NotificationHubs.iOS.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Plugin.AzurePushNotification.iOS/packages.config
+++ b/src/Plugin.AzurePushNotification.iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Azure.NotificationHubs.iOS" version="1.2.5.2" targetFramework="xamarinios10" />
+  <package id="Xamarin.Azure.NotificationHubs.iOS" version="2.0.4" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
stop using hard-coded nuget version 