### PR TITLE
Fix on iOS Platform

### DIFF
--- a/src/Plugin.AzurePushNotification/AzurePushNotificationManager.apple.cs
+++ b/src/Plugin.AzurePushNotification/AzurePushNotificationManager.apple.cs
@@ -180,7 +180,7 @@ namespace Plugin.AzurePushNotification
         }
         public static void Initialize(string notificationHubConnectionString, string notificationHubPath, NSDictionary options, bool autoRegistration = true, bool enableDelayedResponse = true)
         {
-           
+
             Hub = new SBNotificationHub(notificationHubConnectionString, notificationHubPath);
             TokenKey = new NSString($"{notificationHubPath}_Token");
             PushRegisteredKey = $"{notificationHubPath}_PushRegistered";
@@ -206,7 +206,7 @@ namespace Plugin.AzurePushNotification
 
             if (autoRegistration)
             {
-                 CrossAzurePushNotification.Current.RegisterForPushNotifications();
+                CrossAzurePushNotification.Current.RegisterForPushNotifications();
             }
 
 
@@ -350,44 +350,44 @@ namespace Plugin.AzurePushNotification
 
             await Task.Run(() =>
             {
-                    NSError errorFirst;
-                    if ((InternalToken != null && InternalToken.Length > 0) && IsRegistered)
+                NSError errorFirst;
+                if ((InternalToken != null && InternalToken.Length > 0) && IsRegistered)
+                {
+                    Hub.UnregisterAll(InternalToken, out errorFirst);
+
+                    if (errorFirst != null)
                     {
-                        Hub.UnregisterAll(InternalToken, out errorFirst);
+                        _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubUnregistrationFailed, errorFirst.Description));
+                        System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Unregister- Error - {errorFirst.Description}");
 
-                        if (errorFirst != null)
-                        {
-                            _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubUnregistrationFailed, errorFirst.Description));
-                            System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Unregister- Error - {errorFirst.Description}");
-
-                            return;
-                        }
+                        return;
                     }
+                }
 
-                    NSSet tagSet = null;
-                    if (tags != null && tags.Length > 0)
-                    {
-                        tagSet = new NSSet(tags);
-                    }
+                NSSet tagSet = null;
+                if (tags != null && tags.Length > 0)
+                {
+                    tagSet = new NSSet(tags);
+                }
 
-                    NSError error;
+                NSError error;
 
-                    Hub.RegisterNative(DeviceToken, tagSet, out error);
+                Hub.RegisterNative(DeviceToken, tagSet, out error);
 
-                    if (error != null)
-                    {
-                        System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Register- Error - {error.Description}");
-                        _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubRegistrationFailed, error.Description));
+                if (error != null)
+                {
+                    System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Register- Error - {error.Description}");
+                    _onNotificationError?.Invoke(CrossAzurePushNotification.Current, new AzurePushNotificationErrorEventArgs(AzurePushNotificationErrorType.NotificationHubRegistrationFailed, error.Description));
 
-                    }
-                    else
-                    {
-                        System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Registered - ${_tags}");
+                }
+                else
+                {
+                    System.Diagnostics.Debug.WriteLine($"AzurePushNotification - Registered - ${_tags}");
 
-                        NSUserDefaults.StandardUserDefaults.SetBool(true, PushRegisteredKey);
-                        NSUserDefaults.StandardUserDefaults.SetValueForKey(_tags ?? new NSArray().MutableCopy(), TagsKey);
-                        NSUserDefaults.StandardUserDefaults.Synchronize();
-                    }
+                    NSUserDefaults.StandardUserDefaults.SetBool(true, PushRegisteredKey);
+                    NSUserDefaults.StandardUserDefaults.SetValueForKey(_tags ?? new NSArray().MutableCopy(), TagsKey);
+                    NSUserDefaults.StandardUserDefaults.Synchronize();
+                }
             });
 
         }
@@ -559,9 +559,7 @@ namespace Plugin.AzurePushNotification
             {
                 if (val.Key.Equals(keyAps))
                 {
-                    NSDictionary aps = data.ValueForKey(keyAps) as NSDictionary;
-
-                    if (aps != null)
+                    if (data.ValueForKey(keyAps) is NSDictionary aps)
                     {
                         foreach (var apsVal in aps)
                         {
@@ -571,17 +569,34 @@ namespace Plugin.AzurePushNotification
                                 {
                                     foreach (var alertVal in apsVal.Value as NSDictionary)
                                     {
-                                        parameters.Add($"aps.alert.{alertVal.Key}", $"{alertVal.Value}");
+                                        if (alertVal.Value is NSDictionary)
+                                        {
+                                            var value = ((NSDictionary)alertVal.Value).ToJson();
+                                            parameters.Add($"aps.alert.{alertVal.Key}", value);
+                                        }
+                                        else
+                                        {
+                                            parameters.Add($"aps.alert.{alertVal.Key}", $"{alertVal.Value}");
+                                        }
                                     }
+                                }
+                                else
+                                {
+                                    var value = ((NSDictionary)apsVal.Value).ToJson();
+                                    parameters.Add($"aps.{apsVal.Key}", value);
                                 }
                             }
                             else
                             {
                                 parameters.Add($"aps.{apsVal.Key}", $"{apsVal.Value}");
                             }
-
                         }
                     }
+                }
+                else if (val.Value is NSDictionary)
+                {
+                    var value = ((NSDictionary)val.Value).ToJson();
+                    parameters.Add($"{val.Key}", value);
                 }
                 else
                 {
@@ -593,6 +608,7 @@ namespace Plugin.AzurePushNotification
 
             return parameters;
         }
+
         public void ClearAllNotifications()
         {
             if (UIDevice.CurrentDevice.CheckSystemVersion(10, 0))
@@ -635,5 +651,15 @@ namespace Plugin.AzurePushNotification
             }
         }
 
+    }
+
+    public static class HelperExtensions
+    {
+        public static string ToJson(this NSDictionary dictionary)
+        {
+            var json = NSJsonSerialization.Serialize(dictionary,
+            NSJsonWritingOptions.SortedKeys, out NSError error);
+            return json.ToString(NSStringEncoding.UTF8);
+        }
     }
 }

--- a/src/Plugin.AzurePushNotification/AzurePushNotificationManager.apple.cs
+++ b/src/Plugin.AzurePushNotification/AzurePushNotificationManager.apple.cs
@@ -267,7 +267,7 @@ namespace Plugin.AzurePushNotification
         {
             UIApplication.SharedApplication.UnregisterForRemoteNotifications();
             Token = string.Empty;
-            InternalToken = null;
+            InternalToken = string.Empty;
         }
 
         static void RegisterUserNotificationCategories(NotificationUserCategory[] userCategories)
@@ -563,15 +563,15 @@ namespace Plugin.AzurePushNotification
                     {
                         foreach (var apsVal in aps)
                         {
-                            if (apsVal.Value is NSDictionary)
+                            if (apsVal.Value is NSDictionary apsValDict)
                             {
                                 if (apsVal.Key.Equals(keyAlert))
                                 {
-                                    foreach (var alertVal in apsVal.Value as NSDictionary)
+                                    foreach (var alertVal in apsValDict)
                                     {
-                                        if (alertVal.Value is NSDictionary)
+                                        if (alertVal.Value is NSDictionary valDict)
                                         {
-                                            var value = ((NSDictionary)alertVal.Value).ToJson();
+                                            var value = valDict.ToJson();
                                             parameters.Add($"aps.alert.{alertVal.Key}", value);
                                         }
                                         else
@@ -582,7 +582,7 @@ namespace Plugin.AzurePushNotification
                                 }
                                 else
                                 {
-                                    var value = ((NSDictionary)apsVal.Value).ToJson();
+                                    var value = apsValDict.ToJson();
                                     parameters.Add($"aps.{apsVal.Key}", value);
                                 }
                             }
@@ -593,18 +593,16 @@ namespace Plugin.AzurePushNotification
                         }
                     }
                 }
-                else if (val.Value is NSDictionary)
+                else if (val.Value is NSDictionary valDict)
                 {
-                    var value = ((NSDictionary)val.Value).ToJson();
+                    var value = valDict.ToJson();
                     parameters.Add($"{val.Key}", value);
                 }
                 else
                 {
                     parameters.Add($"{val.Key}", $"{val.Value}");
                 }
-
             }
-
 
             return parameters;
         }


### PR DESCRIPTION
1. Fixes to NSUserDefaults null error by changing `InternalToken = null` to `InternalToken = string.Empty`

2.

Problem: #https://github.com/CrossGeeks/PushNotificationPlugin/issues/80

This PR handles the default NSDictionary to string behavior which generates a non easily parse-able string.

{\n
    destination =     {\n
        section = notifications;\n
        type = none;\n
        uri = "<null>";\n
    };\n
}
Current code will convert it to json so it can be parsed upon opening or receiving.