### PR TITLE
Enable iOS Startup Notifications

### DIFF
--- a/src/Plugin.AzurePushNotification/AzurePushNotificationManager.apple.cs
+++ b/src/Plugin.AzurePushNotification/AzurePushNotificationManager.apple.cs
@@ -195,7 +195,7 @@ namespace Plugin.AzurePushNotification
             PushRegisteredKey = $"{notificationHubPath}_PushRegistered";
             CrossAzurePushNotification.Current.NotificationHandler = CrossAzurePushNotification.Current.NotificationHandler ?? new DefaultPushNotificationHandler();
 
-            /*if (options?.ContainsKey(UIApplication.LaunchOptionsRemoteNotificationKey) ?? false)
+            if (options?.ContainsKey(UIApplication.LaunchOptionsRemoteNotificationKey) ?? false)
             {
                 var pushPayload = options[UIApplication.LaunchOptionsRemoteNotificationKey] as NSDictionary;
                 if (pushPayload != null)
@@ -211,7 +211,7 @@ namespace Plugin.AzurePushNotification
 
                     CrossAzurePushNotification.Current.NotificationHandler?.OnOpened(notificationResponse);
                 }
-            }*/
+            }
 
             if (autoRegistration)
             {


### PR DESCRIPTION
**Enable iOS Startup Notifications**

If the iOS app is killed and we receive a notification there is no action on it.
I have uncommented the existing code, and its working flawlessly.